### PR TITLE
[2022.10.19] 연결 가능한 Local IP 검증 소켓 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "~4.16.1",
         "http-errors": "~1.6.3",
         "morgan": "~1.9.1",
+        "os": "^0.1.2",
         "robotjs": "^0.6.0",
         "socket.io": "^4.5.2"
       },
@@ -1689,6 +1690,11 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
     },
     "node_modules/p-is-promise": {
       "version": "3.0.0",
@@ -3943,6 +3949,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
     },
     "p-is-promise": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "morgan": "~1.9.1",
+    "os": "^0.1.2",
     "robotjs": "^0.6.0",
     "socket.io": "^4.5.2"
   },

--- a/services/socket.js
+++ b/services/socket.js
@@ -13,8 +13,6 @@ app.io = require("socket.io")({
 app.io.on("connection", (socket) => {
   socket.on("verify-connectable", (data) => {
     app.io.emit("broadcast", myLocalIpAddress);
-
-    console.log("socket.on ~ myLocalIpAddress", myLocalIpAddress);
   });
 
   socket.on("user-send", (data) => {

--- a/services/socket.js
+++ b/services/socket.js
@@ -1,5 +1,8 @@
 const app = require("../app");
 const robot = require("robotjs");
+const os = require("os");
+
+const myLocalIpAddress = os.networkInterfaces().en0[1].address;
 
 app.io = require("socket.io")({
   cors: {
@@ -8,6 +11,12 @@ app.io = require("socket.io")({
 });
 
 app.io.on("connection", (socket) => {
+  socket.on("verify-connectable", (data) => {
+    app.io.emit("broadcast", myLocalIpAddress);
+
+    console.log("socket.on ~ myLocalIpAddress", myLocalIpAddress);
+  });
+
   socket.on("user-send", (data) => {
     const { x: xPosition, y: yPosition } = robot.getMousePos();
 


### PR DESCRIPTION
# Topic
- 연결 가능한 Local IP 검증 소켓 구현 완료

# Detail
- 클라이언트에서 Socket을 통해 emit을 보내면 Package가 설치된 PC의 Local IP를 클라이언트에게 broadcast해준다.

# Kanban Link
https://www.notion.so/vanillacoding/Layout-PC-361411513bba48d2ac537b023d9f7691

# Kanban List
- [x]  [Package] 클라이언트에서 Package가 설치된 Local IP로 Socket 데이터를 전송하면 Package가 설치된 Local IP를 broadcst한다.

# ETC
- 해당사항 없음