### PR TITLE
[2022.10.21] Gesture 추가기능 구현 - Volume Up Down

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-package",
-  "version": "0.0.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portable-trackpad-package",
   "bin": "./bin/www",
-  "version": "0.0.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/services/socket.js
+++ b/services/socket.js
@@ -39,6 +39,14 @@ app.io.on("connection", (socket) => {
         }
 
         break;
+      case "volume":
+        if (data[1] > 0) {
+          robot.keyTap("audio_vol_up");
+        } else {
+          robot.keyTap("audio_vol_down");
+        }
+
+        break;
       case "dragDown":
         robot.mouseToggle("down");
         break;


### PR DESCRIPTION
# Topic
- Gesture 추가기능 구현 - Volume Up Down

# Detail
- 사용자가 터치패드에서 세 손가락으로 터치 후 회전시킬 경우 PC의 음량을 조절할 수 있도록 기능을 구현한다.
- package 서버로 사용자의 입력된 데이터 정보를 Socket을 통해 보내준다.

# Kanban Link
https://www.notion.so/vanillacoding/TouchPad-e91f68c81f0a447fad130a8244a435b4

# Kanban List
- [x]  유저가 두손가락 이상으로 터치를 한 후 회전하였을때 해당하는 이벤트의 React Native Gesture Handler 매서드를 찾는다.
- [x]  해당 매서드의 정보를 Socket으로 보내준다.

# ETC
- 해당사항 없음