### PR TITLE
[2022.10.22] Gesture 추가기능 구현 - 브라우저 탭 이동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-trackpad-package",
-  "version": "0.9.1",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-trackpad-package",
-      "version": "0.0.0",
+      "version": "0.9.1",
       "dependencies": {
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portable-trackpad-package",
   "bin": "./bin/www",
-  "version": "0.9.1",
+  "version": "0.11.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/services/socket.js
+++ b/services/socket.js
@@ -47,20 +47,28 @@ app.io.on("connection", (socket) => {
         }
 
         break;
+      case "goForwardInTap":
+        robot.keyTap("tab", "control");
+
+        break;
+      case "goBackInTap":
+        robot.keyTap("tab", ["control", "shift"]);
+
+        break;
+      case "goForwardInBrowser":
+        robot.keyTap("]", "command");
+
+        break;
+      case "goBackInBrowser":
+        robot.keyTap("[", "command");
+
+        break;
       case "dragDown":
         robot.mouseToggle("down");
 
         break;
       case "dragUp":
         robot.mouseToggle("up");
-
-        break;
-      case "goForwardInBrowser":
-        robot.keyTap("left", "command");
-
-        break;
-      case "goBackInBrowser":
-        robot.keyTap("right", "command");
 
         break;
     }


### PR DESCRIPTION
# Topic
- Gesture 추가기능 구현 - 브라우저 탭 이동 기능

# Detail
- 사용자가 터치패드에서 네 손가락으로 오른쪽에서 왼쪽으로 드래그하면 현재 탭에서 오른쪽 탭의 화면으로 이동한다.
- 사용자가 터치패드에서 네 손가락으로 왼쪽에서 오른쪽으로 드래그하면 현재 탭에서 왼쪽 탭의 화면으로 이동한다.
- 위의 제스처에 해당하는 데이터 정보를 client로부터 전달받아 pc에서도 동작되도록 robot.js 라이브러리를 이용하여 기능을 구현한다.

# Kanban Link
https://www.notion.so/vanillacoding/TouchPad-b34fc6441ffe4d12bd9a7cc1dd50cfa9

# Kanban List
- [x]  유저가 브라우저상에서 네손가락으로 터치를 한 후 좌우로 드래그하였을때 해당하는 이벤트의 React Native Gesture Handler 매서드를 찾는다.
- [x]  해당 매서드의 정보를 Socket으로 보내준다.

# ETC
- 해당사항 없음