### PR TITLE
[2022.10.26] 제스처로 도형 스케일 조절 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-package",
-  "version": "0.13.1",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portable-trackpad-package",
   "bin": "./bin/www",
-  "version": "0.13.1",
+  "version": "0.14.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/services/socket.js
+++ b/services/socket.js
@@ -76,16 +76,24 @@ app.io.on("connection", (socket) => {
 
   socket.on("drawing", (data) => {
     switch (data[0]) {
-      case "세모":
+      case "triangle":
         app.io.emit("drawing", "triangle");
 
         break;
-      case "네모":
+      case "square":
         app.io.emit("drawing", "square");
 
         break;
-      case "동그라미":
+      case "circle":
         app.io.emit("drawing", "circle");
+
+        break;
+      case "scaleUp":
+        app.io.emit("drawing", "scaleUp");
+
+        break;
+      case "scaleDown":
+        app.io.emit("drawing", "scaleDown");
 
         break;
     }


### PR DESCRIPTION
# Topic
- 제스처로 도형 스케일 조절 기능 구현

# Detail
- 사용자가 제스처 드로잉모드에서 선택한 도형의 크기를 조절할 수 있는 기능 추가.
- react native gesture handler의 pinch 제스처 사용.

# Kanban Link
https://www.notion.so/vanillacoding/4c3a0faa643f4766a47c17c1d20e1b3a

# Kanban List
- [x]  터치패드에서 손가락을 이용하여 제스처를 인식해야 한다.
- [x]  제스처로 도형의 크기를 조절할 수 있어야한다.
- [x]  데이터를 package 파일을 거쳐 drawing 파일에서 적용해야한다.

# ETC
- 해당사항 없음